### PR TITLE
Add Longevity World Cup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Overlaps with [Do-it-yourself biology](https://en.wikipedia.org/wiki/Do-it-yours
 
 :warning: None of this is medical advice. For research use only.
 
+## Projects and Communities
+
+- [Longevity World Cup](https://longevityworldcup.com/) - Open-source biological-age competition where longevity athletes rank by improvements on aging clocks.
+
 ## Books
 
 


### PR DESCRIPTION
Adds Longevity World Cup as a project/community resource.

LWC is an open-source competition where longevity athletes rank by improvements on biological aging clocks, which fits the quantified-self/biohacking overlap described in the README.